### PR TITLE
`rm` method now deletes project folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+/.idea
+/compose.iml
 /target/
 
-//Eclipse settings
+#Eclipse settings
 .settings
 .classpath
 api/.settings
@@ -8,5 +10,6 @@ api/.classpath
 application/.settings
 application/.classpath
 
-//Custom files
+#//Custom files
+
 application/src/test/resources/configuration.properties

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,1 +1,2 @@
+/api.iml
 /target/

--- a/application/.gitignore
+++ b/application/.gitignore
@@ -1,1 +1,2 @@
+/application.iml
 /target/

--- a/application/src/main/java/cloud/benchflow/compose/resources/Projects.java
+++ b/application/src/main/java/cloud/benchflow/compose/resources/Projects.java
@@ -137,9 +137,12 @@ public class Projects {
 		//The services have to be stopped before removal
 		stop(experimentId);
 		
-		java.nio.file.Path projectFolder = Paths.get(this.projectFolder.toString(),experimentId);
+		java.nio.file.Path projectFolder = Paths.get(this.projectFolder,experimentId);
 		DockerComposeWrapper dockerCompose = new DockerComposeWrapper(this.dockerConf);
 		dockerCompose.rm(projectFolder.toString(),experimentId);
+
+		//remove projectFolder
+		Files.delete(projectFolder);
 
 		return null;
 	}


### PR DESCRIPTION
`Project.rm` now deletes `projectFolder` after calling Docker to
undeploy the SUT.
